### PR TITLE
RDKTV-31231: AVOutput plugin documentation

### DIFF
--- a/AVOutput/AVOutputPlugin.json
+++ b/AVOutput/AVOutputPlugin.json
@@ -1,0 +1,2216 @@
+{
+    "$schema": "https://raw.githubusercontent.com/rdkcentral/rdkservices/main/Tools/json_generator/schemas/interface.schema.json",
+    "jsonrpc": "2.0",
+    "info": {
+        "title": "AVOutput API",
+        "class": "AVOutput", 
+        "description": "The `AVOutput` plugin replaces ControlSettings plugin "
+    },
+    "common": {
+        "$ref": "../common/common.json"
+    },
+    "methods": {
+        "getBacklight": {
+            "summary": "Gets the TV user backlight level for a given picture mode, source and format. Regardless of whether auto backlight control is set to ambient or manual getBacklight always return the manual user set backlight level. This method is only available in the RDK TV device profile.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the backlight level should be fetched for",
+			"type": "string",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the backlight level should be fetched for",
+			"type": "string",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the backlight level should be fetched for.",
+			"type": "string",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "backlight" : {
+                        "summary": "The backlight level in the range from - to inclusive.",
+                        "type":"number",
+                        "example": 50
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "backlight",
+                    "success"
+                ]
+            }
+        },
+        "getBacklightCaps": {
+            "summary": "Gets the capability and boundary range for TV user backlight. It returns the range of TV user backlight values that the user can set and the list of possible picture modes, video sources and video formats that the TV user backlight may be customised for.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "platformSupport" : {
+                        "summary": "true: The platform support backlight. false:  The platform does not support backlight.",
+                        "type":"bool",
+                        "example": "true"
+                    },
+                    "range": {
+                        "summary": "Range of values for the TV user backlight.",
+                        "type": "object",
+                        "properties": {
+			    "from" : {
+				"summary": "The lower-inclusive range value for result.backlight.",
+				"type": "number",
+				"example": "0"
+			    },
+			    "to" : {
+				"summary": "The higher-inclusive range value for result.backlight.",
+				"type": "number",
+				"example": "100"
+			    }
+			}
+                    },
+		    "pictureModeInfo": {
+			"summary": "Array of picture modes that the backlight could be customised for. If backlight cannot be customised for picture modes, then this property is not returned.",
+			"type": "array",
+			"example": "["Standard", "Vivid", "Custom", "Movie", "Sports"]"
+		    },
+		    "videoSourceInfo": {
+			"summary": "Array of video sources that the backlight could be customised for. If backlight cannot be customised for video sources, then this property is not returned.",
+			"type": "array",
+			"example": "["Composite1", "HDMI1", "HDMI2", "HDMI3", "IP" ]"
+		    },
+		    "videoFormatInfo": {
+			"summary": "Array of video formats that the backlight could be customised for. If backlight cannot be customised for video format, then this property is not returned.",
+			"type": "array",
+			"example": "["SDR","HLG","HDR10","DV"]"
+		    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "platformSupport",
+                    "range",
+                    "pictureModeInfo",
+		    "videoSourceInfo",
+		    "videoFormatInfo",
+		    "success"
+                ]
+            }
+        },
+        "getBrightness": {
+            "summary": "Gets the TV user brightness level for a given picture mode, source and format.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the brightness level should be fetched for",
+			"type": "string",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the brightness level should be fetched for",
+			"type": "string",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the brightness level should be fetched for.",
+			"type": "string",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "brightness" : {
+                        "summary": "The brightness level in the range from - to inclusive.",
+                        "type":"number",
+                        "example": 50
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "brightness",
+                    "success"
+                ]
+            }
+        },
+        "getBrightnessCaps": {
+            "summary": "Gets the capability and boundary range for TV brightness. It returns the range of TV brightness values that the user can set and the list of possible picture modes, video sources and video formats that the TV brightness may be customised for.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "range": {
+                        "summary": "Range of values for the TV user brightness.",
+                        "type": "object",
+                        "properties": {
+			    "from" : {
+				"summary": "The lower-inclusive range value for result.brightness.",
+				"type": "number",
+				"example": "0"
+			    },
+			    "to" : {
+				"summary": "The higher-inclusive range value for result.brightness.",
+				"type": "number",
+				"example": "100"
+			    }
+			}
+                    },
+		    "pictureModeInfo": {
+			"summary": "Array of picture modes that the brightness could be customised for. If brightness cannot be customised for picture modes, then this property is not returned.",
+			"type": "array",
+			"example": "["Standard", "Vivid", "Custom", "Movie", "Sports"]"
+		    },
+		    "videoSourceInfo": {
+			"summary": "Array of video sources that the brightness could be customised for. If brightness cannot be customised for video sources, then this property is not returned.",
+			"type": "array",
+			"example": "["Composite1", "HDMI1", "HDMI2", "HDMI3", "IP" ]"
+		    },
+		    "videoFormatInfo": {
+			"summary": "Array of video formats that the brightness could be customised for. If brightness cannot be customised for video format, then this property is not returned.",
+			"type": "array",
+			"example": "["SDR","HLG","HDR10","DV"]"
+		    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "range",
+                    "pictureModeInfo",
+		    "videoSourceInfo",
+		    "videoFormatInfo",
+		    "success"
+                ]
+            }
+        },
+        "getContrast": {
+            "summary": "Gets the TV user contrast level for a given picture mode, source and format.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the contrast level should be fetched for",
+			"type": "string",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the contrast level should be fetched for",
+			"type": "string",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the contrast level should be fetched for.",
+			"type": "string",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "contrast" : {
+                        "summary": "The contrast level in the range from - to inclusive.",
+                        "type":"number",
+                        "example": 50
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "contrast",
+                    "success"
+                ]
+            }
+        },
+        "getContrastCaps": {
+            "summary": "Gets the capability and boundary range for TV contrast. It returns the range of TV contrast values that the user can set and the list of possible picture modes, video sources and video formats that the TV contrast may be customised for.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "range": {
+                        "summary": "Range of values for the TV user contrast.",
+                        "type": "object",
+                        "properties": {
+			    "from" : {
+				"summary": "The lower-inclusive range value for result.contrast.",
+				"type": "number",
+				"example": "0"
+			    },
+			    "to" : {
+				"summary": "The higher-inclusive range value for result.contrast.",
+				"type": "number",
+				"example": "100"
+			    }
+			}
+                    },
+		    "pictureModeInfo": {
+			"summary": "Array of picture modes that the contrast could be customised for. If contrast cannot be customised for picture modes, then this property is not returned.",
+			"type": "array",
+			"example": "["Standard", "Vivid", "Custom", "Movie", "Sports"]"
+		    },
+		    "videoSourceInfo": {
+			"summary": "Array of video sources that the contrast could be customised for. If contrast cannot be customised for video sources, then this property is not returned.",
+			"type": "array",
+			"example": "["Composite1", "HDMI1", "HDMI2", "HDMI3", "IP" ]"
+		    },
+		    "videoFormatInfo": {
+			"summary": "Array of video formats that the contrast could be customised for. If contrast cannot be customised for video format, then this property is not returned.",
+			"type": "array",
+			"example": "["SDR","HLG","HDR10","DV"]"
+		    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "range",
+                    "pictureModeInfo",
+		    "videoSourceInfo",
+		    "videoFormatInfo",
+		    "success"
+                ]
+            }
+        },
+        "getSharpness": {
+            "summary": "Gets the TV user sharpness level for a given picture mode, source and format.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the sharpness level should be fetched for",
+			"type": "string",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the sharpness level should be fetched for",
+			"type": "string",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the sharpness level should be fetched for.",
+			"type": "string",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "sharpness" : {
+                        "summary": "The sharpness level in the range from - to inclusive.",
+                        "type":"number",
+                        "example": 50
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "sharpness",
+                    "success"
+                ]
+            }
+        },
+        "getSharpnessCaps": {
+            "summary": "Gets the capability and boundary range for TV sharpness. It returns the range of TV sharpness values that the user can set and the list of possible picture modes, video sources and video formats that the TV sharpness may be customised for.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "range": {
+                        "summary": "Range of values for the TV user sharpness.",
+                        "type": "object",
+                        "properties": {
+			    "from" : {
+				"summary": "The lower-inclusive range value for result.sharpness.",
+				"type": "number",
+				"example": "0"
+			    },
+			    "to" : {
+				"summary": "The higher-inclusive range value for result.sharpness.",
+				"type": "number",
+				"example": "100"
+			    }
+			}
+                    },
+		    "pictureModeInfo": {
+			"summary": "Array of picture modes that the sharpness could be customised for. If sharpness cannot be customised for picture modes, then this property is not returned.",
+			"type": "array",
+			"example": "["Standard", "Vivid", "Custom", "Movie", "Sports"]"
+		    },
+		    "videoSourceInfo": {
+			"summary": "Array of video sources that the sharpness could be customised for. If sharpness cannot be customised for video sources, then this property is not returned.",
+			"type": "array",
+			"example": "["Composite1", "HDMI1", "HDMI2", "HDMI3", "IP" ]"
+		    },
+		    "videoFormatInfo": {
+			"summary": "Array of video formats that the sharpness could be customised for. If sharpness cannot be customised for video format, then this property is not returned.",
+			"type": "array",
+			"example": "["SDR","HLG","HDR10","DV"]"
+		    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "range",
+                    "pictureModeInfo",
+		    "videoSourceInfo",
+		    "videoFormatInfo",
+		    "success"
+                ]
+            }
+        },
+        "getSaturation": {
+            "summary": "Gets the TV user saturation level for a given picture mode, source and format.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the saturation level should be fetched for",
+			"type": "string",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the saturation level should be fetched for",
+			"type": "string",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the saturation level should be fetched for.",
+			"type": "string",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "saturation" : {
+                        "summary": "The saturation level in the range from - to inclusive.",
+                        "type":"number",
+                        "example": 50
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "saturation",
+                    "success"
+                ]
+            }
+        },
+        "getSaturationCaps": {
+            "summary": "Gets the capability and boundary range for TV saturation. It returns the range of TV saturation values that the user can set and the list of possible picture modes, video sources and video formats that the TV saturation may be customised for.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "range": {
+                        "summary": "Range of values for the TV user saturation.",
+                        "type": "object",
+                        "properties": {
+			    "from" : {
+				"summary": "The lower-inclusive range value for result.saturation.",
+				"type": "number",
+				"example": "0"
+			    },
+			    "to" : {
+				"summary": "The higher-inclusive range value for result.saturation.",
+				"type": "number",
+				"example": "100"
+			    }
+			}
+                    },
+		    "pictureModeInfo": {
+			"summary": "Array of picture modes that the saturation could be customised for. If saturation cannot be customised for picture modes, then this property is not returned.",
+			"type": "array",
+			"example": "["Standard", "Vivid", "Custom", "Movie", "Sports"]"
+		    },
+		    "videoSourceInfo": {
+			"summary": "Array of video sources that the saturation could be customised for. If saturation cannot be customised for video sources, then this property is not returned.",
+			"type": "array",
+			"example": "["Composite1", "HDMI1", "HDMI2", "HDMI3", "IP" ]"
+		    },
+		    "videoFormatInfo": {
+			"summary": "Array of video formats that the saturation could be customised for. If satuartion cannot be customised for video format, then this property is not returned.",
+			"type": "array",
+			"example": "["SDR","HLG","HDR10","DV"]"
+		    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "range",
+                    "pictureModeInfo",
+		    "videoSourceInfo",
+		    "videoFormatInfo",
+		    "success"
+                ]
+            }
+        },
+        "getHue": {
+            "summary": "Gets the TV user hue level for a given picture mode, source and format.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the hue level should be fetched for",
+			"type": "string",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the hue level should be fetched for",
+			"type": "string",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the hue level should be fetched for.",
+			"type": "string",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "hue" : {
+                        "summary": "The hue level in the range from - to inclusive.",
+                        "type":"number",
+                        "example": 50
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "hue",
+                    "success"
+                ]
+            }
+        },
+        "getHueCaps": {
+            "summary": "Gets the capability and boundary range for TV hue. It returns the range of TV hue values that the user can set and the list of possible picture modes, video sources and video formats that the TV hue may be customised for.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "range": {
+                        "summary": "Range of values for the TV user hue.",
+                        "type": "object",
+                        "properties": {
+			    "from" : {
+				"summary": "The lower-inclusive range value for result.hue.",
+				"type": "number",
+				"example": "0"
+			    },
+			    "to" : {
+				"summary": "The higher-inclusive range value for result.hue.",
+				"type": "number",
+				"example": "100"
+			    }
+			}
+                    },
+		    "pictureModeInfo": {
+			"summary": "Array of picture modes that the hue could be customised for. If hue cannot be customised for picture modes, then this property is not returned.",
+			"type": "array",
+			"example": "["Standard", "Vivid", "Custom", "Movie", "Sports"]"
+		    },
+		    "videoSourceInfo": {
+			"summary": "Array of video sources that the hue could be customised for. If hue cannot be customised for video sources, then this property is not returned.",
+			"type": "array",
+			"example": "["Composite1", "HDMI1", "HDMI2", "HDMI3", "IP" ]"
+		    },
+		    "videoFormatInfo": {
+			"summary": "Array of video formats that the hue could be customised for. If hue cannot be customised for video format, then this property is not returned.",
+			"type": "array",
+			"example": "["SDR","HLG","HDR10","DV"]"
+		    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "range",
+                    "pictureModeInfo",
+		    "videoSourceInfo",
+		    "videoFormatInfo",
+		    "success"
+                ]
+            }
+        },
+        "getColorTemperature": {
+            "summary": "Gets the TV color temperature level for a given picture mode, source and format.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the color temperature level should be fetched for",
+			"type": "string",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the color temperature level should be fetched for",
+			"type": "string",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the color temperature level should be fetched for.",
+			"type": "string",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "colorTemperature" : {
+                        "summary": "The color temperature currently set",
+                        "type":"string",
+                        "example": 50
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "colorTemperature",
+                    "success"
+                ]
+            }
+        },
+        "getColorTemperatureCaps": {
+            "summary": "Gets the capability and boundary range for TV color temperature. It returns the range of TV user color temperature values that the user can set and the list of possible picture modes, video sources and video formats that the TV user color temperature may be customised for",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "options": {
+                        "summary": "The array of available color temperature options.",
+                        "type": "object",
+                        "example": "["Standard" , "Warm" , "Cold" , "User Defined"]" 
+                    },
+		    "pictureModeInfo": {
+			"summary": "Array of picture modes that the color temperature could be customised for. If hue cannot be customised for picture modes, then this property is not returned.",
+			"type": "array",
+			"example": "["Standard", "Vivid", "Custom", "Movie", "Sports"]"
+		    },
+		    "videoSourceInfo": {
+			"summary": "Array of video sources that the color temperature could be customised for. If hue cannot be customised for video sources, then this property is not returned.",
+			"type": "array",
+			"example": "["Composite1", "HDMI1", "HDMI2", "HDMI3", "IP" ]"
+		    },
+		    "videoFormatInfo": {
+			"summary": "Array of video formats that the color temperature could be customised for. If hue cannot be customised for video format, then this property is not returned.",
+			"type": "array",
+			"example": "["SDR","HLG","HDR10","DV"]"
+		    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "options",
+                    "pictureModeInfo",
+		    "videoSourceInfo",
+		    "videoFormatInfo",
+		    "success"
+                ]
+            }
+        },
+        "getZoomMode": {
+            "summary": "Gets the current TV zoom mode.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the zoom mode should be fetched for",
+			"type": "string",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the zoom mode should be fetched for",
+			"type": "string",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the zoom mode should be fetched for.",
+			"type": "string",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "zoomMode" : {
+                        "summary": "The zoom mode currently set",
+                        "type":"string",
+                        "example": "TV NORMAL"
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "colorTemperature",
+                    "success"
+                ]
+            }
+        },
+        "getZoomModeCaps": {
+            "summary": "Gets the  capability for TV zoom mode.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "options": {
+                        "summary": "Array of available zoom modes.",
+                        "type": "object",
+                        "example": "["Standard" , "Warm" , "Cold" , "User Defined"]" 
+                    },
+		    "pictureModeInfo": {
+			"summary": "Array of picture modes that the zoom mode could be customised for. If hue cannot be customised for picture modes, then this property is not returned.",
+			"type": "array",
+			"example": "["Standard", "Vivid", "Custom", "Movie", "Sports"]"
+		    },
+		    "videoSourceInfo": {
+			"summary": "Array of video sources that the zoom mode could be customised for. If hue cannot be customised for video sources, then this property is not returned.",
+			"type": "array",
+			"example": "["Composite1", "HDMI1", "HDMI2", "HDMI3", "IP" ]"
+		    },
+		    "videoFormatInfo": {
+			"summary": "Array of video formats that the zoom mode could be customised for. If hue cannot be customised for video format, then this property is not returned.",
+			"type": "array",
+			"example": "["SDR","HLG","HDR10","DV"]"
+		    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "options",
+                    "pictureModeInfo",
+		    "videoSourceInfo",
+		    "videoFormatInfo",
+		    "success"
+                ]
+            }
+        },
+        "getDolbyVisionMode": {
+            "summary": "Gets the DolbyVision mode for a given picture mode  and video source.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the DolbyVision mode should be fetched for",
+			"type": "string",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the DolbyVision mode should be fetched for",
+			"type": "string",
+			"example": "Composite1"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "dolbyVisionMode" : {
+                        "summary": "The DolbyVision mode requested",
+                        "type":"string",
+                        "example": "Bright"
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "dolbyVisionMode",
+                    "success"
+                ]
+            }
+        },
+        "getDolbyVisionModeCaps": {
+            "summary": "Gets the capability for DolbyVision mode. It returns the options of DolbyVision mode values that the user can set and the list of possible picture modes and video sources that the DolbyVision mode may be customised for",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "platformSupport": {
+                        "summary": "true: The platform support DolbyVision mode. false:  The platform does not support DolbyVision mode.",
+                        "type": "bool",
+                        "example": "true" 
+                    },
+                    "options": {
+                        "summary": "Array of available options of DolbyVision modes",
+                        "type": "object",
+                        "example": "["Dark", "Bright"]" 
+                    },
+		    "pictureModeInfo": {
+			"summary": "Array of picture modes that the DolbyVision mode could be customised for. If hue cannot be customised for picture modes, then this property is not returned.",
+			"type": "array",
+			"example": "["Standard", "Vivid", "Custom", "Movie", "Sports"]"
+		    },
+		    "videoSourceInfo": {
+			"summary": "Array of video sources that the DolbyVision mode could be customised for. If hue cannot be customised for video sources, then this property is not returned.",
+			"type": "array",
+			"example": "["Composite1", "HDMI1", "HDMI2", "HDMI3", "IP" ]"
+		    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+		    "platformSupport",
+                    "options",
+                    "pictureModeInfo",
+		    "videoSourceInfo",
+		    "videoFormatInfo",
+		    "success"
+                ]
+            }
+        },
+        "getHDR10Mode": {
+            "summary": "Gets the HDR10 mode for a given picture mode  and video source.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the HDR10 mode should be fetched for",
+			"type": "string",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the HDR10 mode should be fetched for",
+			"type": "string",
+			"example": "Composite1"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "dolbyVisionMode" : {
+                        "summary": "The HDR10 mode requested",
+                        "type":"string",
+                        "example": "Bright"
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "HDR10",
+                    "success"
+                ]
+            }
+        },
+        "getHDR10ModeCaps": {
+            "summary": "Gets the capability for HDR10 mode. It returns the options of HDR10 mode values that the user can set and the list of possible picture modes and video sources that the HDR10 mode may be customised for",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "platformSupport": {
+                        "summary": "true: The platform supports HDR10 mode. false:  The platform does not support HDR10 mode.",
+                        "type": "bool",
+                        "example": "true" 
+                    },
+                    "options": {
+                        "summary": "Array of available options of HDR10 modes",
+                        "type": "object",
+                        "example": "["Dark", "Bright"]" 
+                    },
+		    "pictureModeInfo": {
+			"summary": "Array of picture modes that the HDR10 mode could be customised for. If hue cannot be customised for picture modes, then this property is not returned.",
+			"type": "array",
+			"example": "["Standard", "Vivid", "Custom", "Movie", "Sports"]"
+		    },
+		    "videoSourceInfo": {
+			"summary": "Array of video sources that the HDR10 mode could be customised for. If hue cannot be customised for video sources, then this property is not returned.",
+			"type": "array",
+			"example": "["Composite1", "HDMI1", "HDMI2", "HDMI3", "IP" ]"
+		    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+		    "platformSupport",
+                    "options",
+                    "pictureModeInfo",
+		    "videoSourceInfo",
+		    "videoFormatInfo",
+		    "success"
+                ]
+            }
+        },
+        "getHLGMode": {
+            "summary": "Gets the HLG mode for a given picture mode  and video source.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the HLG mode should be fetched for",
+			"type": "string",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the HLG mode should be fetched for",
+			"type": "string",
+			"example": "Composite1"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "dolbyVisionMode" : {
+                        "summary": "The HLG mode requested",
+                        "type":"string",
+                        "example": "Bright"
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "HLG",
+                    "success"
+                ]
+            }
+        },
+        "getHLGModeCaps": {
+            "summary": "Gets the capability for HLG mode. It returns the options of HLG mode values that the user can set and the list of possible picture modes and video sources that the HLG mode may be customised for.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "platformSupport": {
+                        "summary": "true: The platform support HLG mode. false:  The platform does not support HLG mode.",
+                        "type": "bool",
+                        "example": "true" 
+                    },
+                    "options": {
+                        "summary": "Array of available options of HLG modes",
+                        "type": "object",
+                        "example": "["Dark", "Bright"]" 
+                    },
+		    "pictureModeInfo": {
+			"summary": "Array of picture modes that the HLG mode could be customised for. If hue cannot be customised for picture modes, then this property is not returned.",
+			"type": "array",
+			"example": "["Standard", "Vivid", "Custom", "Movie", "Sports"]"
+		    },
+		    "videoSourceInfo": {
+			"summary": "Array of video sources that the HLG mode could be customised for. If hue cannot be customised for video sources, then this property is not returned.",
+			"type": "array",
+			"example": "["Composite1", "HDMI1", "HDMI2", "HDMI3", "IP" ]"
+		    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+		    "platformSupport",
+                    "options",
+                    "pictureModeInfo",
+		    "videoSourceInfo",
+		    "videoFormatInfo",
+		    "success"
+                ]
+            }
+        },
+        "getVideoFormatCaps": {
+            "summary": "Get all supported video formats for the platform",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "options": {
+                        "summary": "Array of video formats that the system can support. These are few examples of video formats available in this array:",
+                        "type": "Array",
+			"example": "["HDR10", "HLG", "SDR", "DV"]"
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "options",
+		    "success"
+                ]
+            }
+        },
+        "getVideoSourceCaps": {
+            "summary": "Get all supported video formats for the platform",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "options": {
+                        "summary": "Array of video sources that the system can support. These are few examples of vidoe sources available in this array",
+                        "type": "Array",
+			"example": "["HDMI1", "HDMI2", "HDMI3", "IP", "Tuner", "Composite1"]"
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "options",
+		    "success"
+                ]
+            }
+        },
+        "getVideoFrameRateCaps": {
+            "summary": "Get all supported video frame rates for the platform.",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "options": {
+                        "summary": "Array of video frame rates that the system can support. These are few examples of video frame rates available in this array",
+                        "type": "Array",
+			"example": "[24,30,50,60]"
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "options",
+		    "success"
+                ]
+            }
+        },
+        "getVideoResolutionCaps": {
+            "summary": "Get all supported video resolutions for the platform",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "maxResolution": {
+                        "summary": "The maximum resolution supported by the system.",
+                        "type": "string",
+			"example": "4096*2160p"
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "maxResolution",
+		    "success"
+                ]
+            }
+        },
+        "getPictureMode": {
+            "summary": "Get picture mode for a given video source and video format",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "videoSource": {
+			"summary": "The video source that the picture mode should be fetched for",
+			"type": "string",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the picture mode should be fetched for.",
+			"type": "string",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "pictureMode" : {
+                        "summary": "The picture mode string requested",
+                        "type":"string",
+                        "example": "Standard"
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "pictureMode",
+                    "success"
+                ]
+            }
+        },
+        "getPictureModeCaps": {
+            "summary": "Get the list of picture modes supported and the list of video sources and video formats against which a picture mode can be associated with",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "options": {
+                        "summary": "Array picture modes supported",
+                        "type": "array",
+			"example": "["Standard","Movie","Game","Custom","Vivid"]"
+			}
+                    },
+		    "videoSourceInfo": {
+			"summary": "Array of video sources that the picture modes could be customised for. If picture modes cannot be customised for video sources, then this property is not returned.",
+			"type": "array",
+			"example": "["Composite1", "HDMI1", "HDMI2", "HDMI3", "IP" ]"
+		    },
+		    "videoFormatInfo": {
+			"summary": "Array of video formats that the picture modes could be customised for. If picture modes cannot be customised for video format, then this property is not returned.",
+			"type": "array",
+			"example": "["SDR","HLG","HDR10","DV"]"
+		    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "options",
+		    "videoSourceInfo",
+		    "videoFormatInfo",
+		    "success"
+                ]
+            }
+        },
+        "getVideoFormat": {
+            "summary": "Returns the the video format of the currently played video content",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "currentVideoFormat" : {
+                        "summary": "The current video format of the video played",
+                        "type":"string",
+                        "example": "SDR"
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "currentVideoFormat",
+                    "success"
+                ]
+            }
+        },
+        "getVideoSource": {
+            "summary": "Returns the the video source selected",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "currentVideoSource" : {
+                        "summary": "The current video source selected",
+                        "type":"string",
+                        "example": "HDMI1"
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "currentVideoSource",
+                    "success"
+                ]
+            }
+        },
+        "getVideoFrameRate": {
+            "summary": "Returns the the video frame rate of the video being played",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "currentVideoFrameRate" : {
+                        "summary": "The current video frame rate of the video being played",
+                        "type":"number",
+                        "example": 20
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "currentVideoFrameRate",
+                    "success"
+                ]
+            }
+        },
+        "getVideoContentType": {
+            "summary": "Returns the FilmMaker mode status if it is enabled or disabled and in which sources the FilmMaker mode is active",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "currentFilmMakerMode" : {
+                        "summary": "Possible values are true and false. true - Flim Maker mode active. false -Film Maker mode not active",
+                        "type":"bool",
+                        "example": true
+                    },
+                    "currentFilmMakerModeSources" : {
+                        "summary": "A list of sources in which the Film Maker mode event occurred. If there params.currentFilmMakerMode is false this parmaeter is not passed",
+                        "type":"array",
+                        "example": "["HDMI1","IP"]"
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "currentFilmMakerMode",
+		    "currentFilmMakerModeSources",
+                    "success"
+                ]
+            }
+        },
+        "getVideoResolution": {
+            "summary": "Returns the the video resolution of the video being played",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "currentVideoResolution" : {
+                        "summary": "The current video resolution of the video being played",
+                        "type":"string",
+                        "example": "720*240p"
+                    },
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "currentVideoResolution",
+                    "success"
+                ]
+            }
+        },
+        "setPictureMode": {
+            "summary": "Set picture mode for a given video source and video format",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode to be associated with the specified video source and video format",
+			"type": "string",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the picture mode should be fetched for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the picture mode should be fetched for.",
+			"type": "array",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "setBacklight": {
+            "summary": "Sets the TV user backlight level for a given picture mode, video format and video source. The backlight value that is to be set should be within the range which is returned by the API getBacklightCaps. If the auto backlight control is set to ambient, the TV user backlight changes made by this API will not take effect until auto backlight control is switched to manual",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the backlight level is customised for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the backlight should be fetched for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the backlight should be fetched for.",
+			"type": "array",
+			"example": "SDR"
+		    },
+		    "backlight": {
+			"summary": "The backlight value to be set. It should be within the range as retrieved from getBacklightCaps",
+			"type": "number",
+			"example": 50
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "setBrightness": {
+            "summary": "Sets the TV brightness level for a given picture mode, video format and video source. The brightness value that is to be set should be within the range which is returned by the API getBrightnessCaps",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the brightness level is customised for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the brightness should be fetched for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the brightness should be fetched for.",
+			"type": "array",
+			"example": "SDR"
+		    },
+		    "backlight": {
+			"summary": "The brightness value to be set. It should be within the range as retrieved from getBrightnessCaps",
+			"type": "number",
+			"example": 50
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "setContrast": {
+            "summary": "Sets the TV contrast level for a given picture mode, video format and video source. The contrast value that is to be set should be within the range which is returned by the API getContrastCaps",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the contrast level is customised for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the contrast should be fetched for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the contrast should be fetched for.",
+			"type": "array",
+			"example": "SDR"
+		    },
+		    "backlight": {
+			"summary": "The contrast value to be set. It should be within the range as retrieved from getContrastCaps",
+			"type": "number",
+			"example": 50
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "setSharpness": {
+            "summary": "Sets the TV sharpness level for a given picture mode, video format and video source. The sharpness value that is to be set should be within the range which is returned by the API getSharpnessCaps",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the sharpness level is customised for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the sharpness should be fetched for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the sharpness should be fetched for.",
+			"type": "array",
+			"example": "SDR"
+		    },
+		    "backlight": {
+			"summary": "The sharpness value to be set. It should be within the range as retrieved from getSharpnessCaps",
+			"type": "number",
+			"example": 50
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "setSaturation": {
+            "summary": "Sets the TV saturation level for a given picture mode, video format and video source. The saturation value that is to be set should be within the range which is returned by the API getSaturationCaps",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the saturation level is customised for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the saturation should be fetched for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the saturation should be fetched for.",
+			"type": "array",
+			"example": "SDR"
+		    },
+		    "backlight": {
+			"summary": "The saturation value to be set. It should be within the range as retrieved from getSaturationCaps",
+			"type": "number",
+			"example": 50
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "setHue": {
+            "summary": "Sets the TV hue level for a given picture mode, video format and video source. The hue value that is to be set should be within the range which is returned by the API getHueCaps",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the hue level is customised for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the hue should be fetched for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the hue should be fetched for.",
+			"type": "array",
+			"example": "SDR"
+		    },
+		    "backlight": {
+			"summary": "The hue value to be set. It should be within the range as retrieved from getHueCaps",
+			"type": "number",
+			"example": 50
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "setColorTemperature": {
+            "summary": "Sets the TV color temperature level for a given picture mode, video format and video source. The color temperature value that is to be set should be within the range which is returned by the API getColorTemperatureCaps",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the color temperature is customised for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the color temperature should be fetched for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the color temperature should be fetched for.",
+			"type": "array",
+			"example": "SDR"
+		    },
+		    "colorTemperature": {
+			"summary": "The color temperature value to be set. It should be within the options as retrieved from getColorTemperatureCaps",
+			"type": "string",
+			"example": "Standard"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "setZoomMode": {
+            "summary": "Sets the TV zoom mode for a given picture mode, video format and video source. The zoom mode that is to be set should be within the range which is returned by the API getZoomModeCaps",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the zoom mode is customised for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the zoom mode should be fetched for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the zoom mode should be fetched for.",
+			"type": "array",
+			"example": "SDR"
+		    },
+		    "zoomMode": {
+			"summary": "The zoom mode value to be set. It should be within the options as retrieved from getZoomModeCaps",
+			"type": "string",
+			"example": "TV AUTO"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "setDolbyVisionMode": {
+            "summary": "Sets the DolbyVision mode for a given picture mode and video format. The DolbyVision mode that is to be set should be within the possible values which are returned by the API getDolbyVisionModeCapsx",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the DolbyVision mode is customised for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the DolbyVision mode should be fetched for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "dolbyVisionMode": {
+			"summary": "The DolbyVision mode value to be set. It should be within the options as retrieved from getDolbyVisionModeCaps",
+			"type": "string",
+			"example": "Dark"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "setHDR10Mode": {
+            "summary": "Sets the HDR10 mode for a given picture mode and video format. The HDR10 mode that is to be set should be within the possible values which are returned by the API getHDR10ModeCaps",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode" : {
+		        "summary": "The picture mode that the HDR10 mode is customised for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the HDR10 mode should be fetched for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "hdr10Mode": {
+			"summary": "The HDR10 mode value to be set. It should be within the options as retrieved from getHDR10ModeCaps",
+			"type": "string",
+			"example": "Dark"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "resetPictureMode": {
+            "summary": "Reset picture mode to default for a given video source and video format",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "videoSource": {
+			"summary": "The video source(s) for which the default picture mode needs to be associated with",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format(s) to which the picture mode needs to be associated with",
+			"type": "array",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "resetBacklight": {
+            "summary": "Resets the TV user Backlight to factory default for a given picture mode, video format and video source. If the auto backlight control is set to ambient, the TV user backlight change to default value made by this API will not take effect until auto backlight control is switched to manual",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode": {
+			"summary": "The picture mode that the backlight level is reset for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the backlight level is reset for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the backlight level is reset for",
+			"type": "array",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "resetBrightness": {
+            "summary": "Resets the TV brightness to factory default for a given picture mode, video format and video source",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode": {
+			"summary": "The picture mode that the brightness level is reset for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the brightness level is reset for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the brightness level is reset for",
+			"type": "array",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "resetContrast": {
+            "summary": "Resets the TV contrast to factory default for a given picture mode, video format and video source",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode": {
+			"summary": "The picture mode that the contrast level is reset for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the contrast level is reset for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the contrast level is reset for",
+			"type": "array",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "resetSharpness": {
+            "summary": "Resets the TV sharpness to factory default for a given picture mode, video format and video source",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode": {
+			"summary": "The picture mode that the sharpness level is reset for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the sharpness level is reset for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the sharpness level is reset for",
+			"type": "array",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "resetSaturation": {
+            "summary": "Resets the TV saturation to factory default for a given picture mode, video format and video source",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode": {
+			"summary": "The picture mode that the saturation level is reset for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the saturation level is reset for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the saturation level is reset for",
+			"type": "array",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "resetHue": {
+            "summary": "Resets the TV hue to factory default for a given picture mode, video format and video source",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode": {
+			"summary": "The picture mode that the hue level is reset for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the hue level is reset for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the hue level is reset for",
+			"type": "array",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "resetColorTemperature": {
+            "summary": "Resets the TV color temperature to factory default for a given picture mode, video format and video source",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode": {
+			"summary": "The picture mode that the color temperature is reset for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the color temperature is reset for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the color temperature is reset for",
+			"type": "array",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "resetZoomMode": {
+            "summary": "Resets the TV zoom mode to the factory default",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode": {
+			"summary": "The picture mode that the zoom mode is reset for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the zoom mode is reset for",
+			"type": "array",
+			"example": "Composite1"
+		    },
+		    "videoFormat": {
+			"summary": "The video format that the zoom mode is reset for",
+			"type": "array",
+			"example": "SDR"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "resetDolbyVisionMode": {
+            "summary": "Resets the DolbyVision mode to factory default for a given picture mode and video format",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode": {
+			"summary": "The picture mode that the DolbyVision mode is reset for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the DolbyVision mode is reset for",
+			"type": "array",
+			"example": "Composite1"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "resetHDR10Mode": {
+            "summary": "Resets the HDR10 mode to factory default for a given picture mode and video format",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode": {
+			"summary": "The picture mode that the HDR10 mode is reset for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the HDR10 mode is reset for",
+			"type": "array",
+			"example": "Composite1"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        },
+        "resetHLGMode": {
+            "summary": "Resets the HLG mode to factory default for a given picture mode and video format",
+            "params": {
+                "summary": "An empty parameter object",
+                "type": "object",
+                "properties": {
+		    "pictureMode": {
+			"summary": "The picture mode that the HLG mode is reset for",
+			"type": "array",
+			"example": "Standard"
+		    },
+		    "videoSource": {
+			"summary": "The video source that the HLG mode is reset for",
+			"type": "array",
+			"example": "Composite1"
+		    }
+		}
+            },
+            "result": {
+                "type":"object",
+                "properties": {
+                    "success": {
+                        "$ref": "#/common/success"
+                    }
+                },
+                "required": [
+                    "success"
+                ]
+            }
+        }
+    },
+    "events": {
+        "Video source change event": {
+            "summary": "Event notification when there is a change in video source of the video being played",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "currentVideoSource":{
+                        "summary": "Video source of the video currently being played. None - Returned when no active video is played. For full list of supported video formats refer getVideoSourceCaps",
+			"type": "string",
+			"example": "HDMI1"
+                    }
+                },
+                "required": [
+                    "currentVideoSource"
+                ]
+            }
+        },
+        "Video format change event": {
+            "summary": "Event notification when there is a change in video format of the video being played",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "currentVideoFormat":{
+                        "summary": "Video format of the video currently being played. None - Returned when no active video is played. For full list of supported video formats refer getVideoFormatCaps",
+			"type": "string",
+			"example": "SDR"
+                    }
+                },
+                "required": [
+                    "currentVideoFormat"
+                ]
+            }
+        },
+        "Video Resolution change event": {
+            "summary": "At present this event is supported only for HDMI and COMPOSITE1 video sources only. Event notification when there is a change in video resolution of the current video played out on HDMI and COMPOSITE1 video sources when they are selected. ",
+            "params": {
+                "type":"object",
+                "properties": {
+                    "currentVideoResolution":{
+                        "summary": "Video resolution of the video currently being played. None - Returned when no active video is played. For full list of supported video formats refer getVideoResolutionCaps",
+			"type": "string",
+			"example": "720*240p"
+                    }
+                },
+                "required": [
+                    "currentVideoResolution"
+                ]
+            }
+        },
+        "Video Frame Rate change event": {
+            "summary": "At present this event is supported only for HDMI and COMPOSITE1 video sources only. Event notification when there is a change in video frame rate of the video being played",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "currentVideoFrameRate": {
+                        "summary": "Video frame rate of the video currently being played.None - Returned when no video is played. For full list of supported video frame rates refer getVideoFrameRateCaps",
+			"type": "number",
+			"example": 25
+                    }
+		},
+                "required": [
+                    "currentVideoFrameRate"
+                ]
+            }
+        },
+        "Video Content change event": {
+            "summary": "Event notification when there is aany form of video content changes were detected. An example of such a change is detection of FilmMaker mode",
+            "params": {
+                "type": "object",
+                "properties": {
+                    "filmMakerMode": {
+                        "summary": "Possible values are true and false. true - Flim Maker mode active. false -Film Maker mode not active",
+			"type": "bool",
+			"example": true
+                    },
+                    "filmMakerModeSources": {
+                        "summary": "A list of sources in which the Film Maker mode event occurred. If there params.filmMakerMode is false this parmaeter is not passed.Possible video sources for film maker mode are HDMI sources (as returned by getVideoSourceCaps) and IP source",
+			"type": "array",
+			"example": "["HDMI1", "HDMI2", "HDMI3", "IP", "Tuner", "Composite1"]"
+                    }
+		},
+                "required": [
+                    "filmMakerMode",
+		    "filmMakerModeSources"
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
Reason for change: To keep the plugin documentation within the plugin
Test Procedure: refer ticket
Risks: Low
Priority: P2
Signed-off-by: Anju Raveendran anju.raveendran@sky.uk